### PR TITLE
Add sign-out handling to enhanced affiliate dashboard

### DIFF
--- a/src/layouts/EnhancedAffiliateDashboardLayout.tsx
+++ b/src/layouts/EnhancedAffiliateDashboardLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
@@ -36,7 +36,22 @@ import { useFastAuth } from '@/hooks/useFastAuth';
 
 const EnhancedAffiliateDashboardLayout: React.FC = () => {
   const location = useLocation();
-  const { profile } = useFastAuth();
+  const navigate = useNavigate();
+  const { profile, signOut } = useFastAuth();
+
+  const handleSignOut = async () => {
+    try {
+      const { error } = await signOut();
+
+      if (error) {
+        console.error('Error signing out:', error);
+      }
+    } catch (error) {
+      console.error('Unexpected error during sign out:', error);
+    } finally {
+      navigate('/auth', { replace: true });
+    }
+  };
 
   // جلب المتاجر الخاصة بالمسوق
   const { data: stores } = useQuery({
@@ -260,7 +275,10 @@ const EnhancedAffiliateDashboardLayout: React.FC = () => {
                       <span>إعدادات المتجر</span>
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                    <DropdownMenuItem className="text-destructive cursor-pointer">
+                    <DropdownMenuItem
+                      className="text-destructive cursor-pointer"
+                      onSelect={handleSignOut}
+                    >
                       <span>تسجيل الخروج</span>
                     </DropdownMenuItem>
                   </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- extract `signOut` and navigation utilities in the enhanced affiliate dashboard layout
- invoke `signOut` from the logout menu item and route users back to the auth entry point
- add basic error logging to catch sign-out issues before redirecting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d33c79085c832d93c74234c13c7ab3