### PR TITLE
Fix affiliate store management navigation

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -68,7 +68,7 @@ const Index = () => {
     if (profile?.role === 'admin') {
       navigate('/admin/dashboard');
     } else if (profile?.role === 'affiliate') {
-      navigate('/merchant');
+      navigate('/dashboard');
     } else if (profile?.role === 'merchant') {
       navigate('/merchant');
     } else {


### PR DESCRIPTION
## Summary
- update the store management click handler so affiliates go to `/dashboard` while preserving merchant and admin destinations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d338deed7c832db05259cc0289df62