### PR TITLE
Fix missing ShoppingBag icon import on Index page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -25,6 +25,7 @@ import {
   CreditCard,
   LineChart,
   ArrowUpRight,
+  ShoppingBag,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
## Summary
- add the ShoppingBag icon to the lucide-react import block so the admin metrics card renders without errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d604e38018832d895434800b7dcc32