### PR TITLE
Guard error tracking initialization for server environments

### DIFF
--- a/src/components/monitoring/MonitoringDashboard.tsx
+++ b/src/components/monitoring/MonitoringDashboard.tsx
@@ -16,7 +16,7 @@ import {
   Bug,
   Zap
 } from 'lucide-react';
-import { errorTracker } from '@/utils/errorTracking';
+import { getErrorTracker } from '@/utils/errorTracking';
 import { AnalyticsUtils } from '@/hooks/useAnalytics';
 import { ABTestUtils } from '@/components/testing/ABTestProvider';
 
@@ -30,6 +30,7 @@ interface DashboardStats {
 }
 
 export const MonitoringDashboard: React.FC = () => {
+  const errorTracker = getErrorTracker();
   const [stats, setStats] = useState<DashboardStats>({
     totalErrors: 0,
     criticalErrors: 0,


### PR DESCRIPTION
## Summary
- guard the error tracker so DOM-specific listeners are only registered when running in the browser
- expose a lazy `getErrorTracker` helper and update analytics consumers to use it safely on the client

## Testing
- npm run test -- --watch=false *(passes but the process does not exit automatically and had to be interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_b_68d6ab74e1a8832dac51396253d282c7