### PR TITLE
Redirect authenticated users from auth screen once ready

### DIFF
--- a/src/features/auth/components/AuthForm.tsx
+++ b/src/features/auth/components/AuthForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -29,12 +29,17 @@ const AuthForm = () => {
   });
 
   const { goToUserHome } = useSmartNavigation();
+  const hasRedirectedRef = useRef(false);
 
   useEffect(() => {
-    if (isAuthenticated && profile?.role) {
-      goToUserHome(profile.role);
+    if (!loading && isAuthenticated && !hasRedirectedRef.current) {
+      hasRedirectedRef.current = true;
+      goToUserHome(profile?.role);
     }
-  }, [isAuthenticated, profile?.role, goToUserHome]);
+    if (!isAuthenticated) {
+      hasRedirectedRef.current = false;
+    }
+  }, [goToUserHome, isAuthenticated, loading, profile?.role]);
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -42,17 +42,17 @@ import { useUserDataContext } from '@/contexts/UserDataContext';
 
 const Index = () => {
   const navigate = useNavigate();
-  const { user, profile, signOut, isAuthenticated } = useFastAuth();
+  const { user, profile, signOut, isAuthenticated, loading } = useFastAuth();
   const { userShop, userStatistics } = useUserDataContext();
   const { isDarkMode, toggleDarkMode } = useDarkMode();
   const { language, toggleLanguage } = useLanguage();
   const { themeId } = useTheme('default');
 
   React.useEffect(() => {
-    if (isAuthenticated === false) {
+    if (!loading && isAuthenticated === false) {
       navigate('/auth', { replace: true });
     }
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, loading, navigate]);
 
   const heroMap = {
     default: DefaultHero3D,


### PR DESCRIPTION
## Summary
- ensure the auth form redirects as soon as authentication completes, even before the profile role loads
- guard against repeated redirects by tracking completion and reset when signing out

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68d6c95a934c832dbbd976e65abea1ac