### PR TITLE
Add Supabase-backed leaderboard API

### DIFF
--- a/src/server/leaderboard/api.ts
+++ b/src/server/leaderboard/api.ts
@@ -1,0 +1,180 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/integrations/supabase/types';
+
+interface AlliancesMonthlyLeaderboardRow {
+  alliance_id: string;
+  alliance_name: string;
+  month_number: number;
+  year_number: number;
+  total_points: number;
+  events_count: number;
+  rank: number;
+}
+
+interface MonthlyLeaderboardRow {
+  user_id: string;
+  profile_name: string | null;
+  month_number: number;
+  year_number: number;
+  points: number;
+  events_count: number;
+  rank: number;
+}
+
+export interface LeaderboardResponse {
+  alliances: AlliancesMonthlyLeaderboardRow[];
+  individuals: MonthlyLeaderboardRow[];
+}
+
+function readEnv(name: string, fallback = ''): string {
+  if (typeof process !== 'undefined' && process.env?.[name]) {
+    return process.env[name] as string;
+  }
+
+  const meta = (typeof import.meta !== 'undefined' && (import.meta as any)?.env) || undefined;
+  if (meta && meta[name]) {
+    return meta[name] as string;
+  }
+
+  return fallback;
+}
+
+const DEFAULT_SUPABASE_URL = 'https://uewuiiopkctdtaexmtxu.supabase.co';
+const DEFAULT_SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVld3VpaW9wa2N0ZHRhZXhtdHh1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYzMjE2ODUsImV4cCI6MjA3MTg5NzY4NX0._q03bmVxGQhCczoBaOHM6mIGbA7_B4B7PZ5mhDefuFA';
+
+const SUPABASE_URL =
+  readEnv('VITE_SUPABASE_URL', readEnv('SUPABASE_URL', DEFAULT_SUPABASE_URL));
+const SUPABASE_ANON_KEY =
+  readEnv('VITE_SUPABASE_ANON_KEY', readEnv('SUPABASE_ANON_KEY', DEFAULT_SUPABASE_ANON_KEY));
+
+function createServerClient(accessToken?: string): SupabaseClient<Database> {
+  return createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+    global: {
+      headers: accessToken
+        ? {
+            Authorization: `Bearer ${accessToken}`,
+          }
+        : {},
+    },
+  });
+}
+
+function parseLimit(searchParams: URLSearchParams, fallback = 50): number {
+  const raw = searchParams.get('limit');
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return Math.min(parsed, 100);
+}
+
+function extractAccessToken(request: Request): string | null {
+  const header = request.headers.get('authorization') ?? request.headers.get('Authorization');
+  if (!header) {
+    return null;
+  }
+
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+export async function fetchMonthlyLeaderboard(accessToken: string, limit = 50): Promise<LeaderboardResponse> {
+  const supabase = createServerClient(accessToken);
+
+  const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
+  if (authError || !authData?.user) {
+    throw Object.assign(new Error('UNAUTHENTICATED'), {
+      status: 401,
+      cause: authError ?? new Error('Missing user'),
+    });
+  }
+
+  const alliancesResult = await supabase
+    .from('alliances_monthly_leaderboard')
+    .select('*')
+    .order('rank', { ascending: true })
+    .limit(limit);
+
+  const alliances = alliancesResult.data as AlliancesMonthlyLeaderboardRow[] | null;
+  const alliancesError = alliancesResult.error;
+
+  if (alliancesError) {
+    throw Object.assign(new Error('Failed to load alliances leaderboard'), {
+      status: 500,
+      cause: alliancesError,
+    });
+  }
+
+  const individualsResult = await supabase
+    .from('monthly_leaderboard')
+    .select('*')
+    .order('rank', { ascending: true })
+    .limit(limit);
+
+  const individuals = individualsResult.data as MonthlyLeaderboardRow[] | null;
+  const individualsError = individualsResult.error;
+
+  if (individualsError) {
+    throw Object.assign(new Error('Failed to load individual leaderboard'), {
+      status: 500,
+      cause: individualsError,
+    });
+  }
+
+  return {
+    alliances: alliances ?? [],
+    individuals: individuals ?? [],
+  };
+}
+
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const token = extractAccessToken(request);
+    if (!token) {
+      return new Response(
+        JSON.stringify({ error: 'Authentication required' }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const url = new URL(request.url, 'http://localhost');
+    const limit = parseLimit(url.searchParams);
+
+    const payload = await fetchMonthlyLeaderboard(token, limit);
+
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const status = (error as { status?: number }).status ?? 500;
+    const message = status === 401 ? 'Authentication required' : 'Failed to load leaderboard';
+
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('Leaderboard API error', error);
+    }
+
+    return new Response(
+      JSON.stringify({ error: message }),
+      {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+}
+
+export type { AlliancesMonthlyLeaderboardRow, MonthlyLeaderboardRow };


### PR DESCRIPTION
## Summary
- add a server-side leaderboard API that authenticates users and queries the Supabase monthly views
- include helpers for environment fallback, pagination limits, and consistent error handling

## Testing
- node --loader ./tests/ts-loader.mjs --test tests/leaderboard.monthly.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d83a23379c832db867643e11a152b9