### PR TITLE
Handle lovableproject domains as store redirects

### DIFF
--- a/src/components/store/DomainManager.tsx
+++ b/src/components/store/DomainManager.tsx
@@ -18,9 +18,9 @@ const DomainManager = ({ children }: DomainManagerProps) => {
     const currentPath = location.pathname;
     const search = location.search;
 
-    const isCustomDomain = hostname !== 'localhost' 
-      && !hostname.includes('atlantiss.tech') 
-      && !hostname.includes('lovableproject.com') 
+    const isLovableProjectDomain = hostname.endsWith('.lovableproject.com');
+    const isCustomDomain = hostname !== 'localhost'
+      && !hostname.includes('atlantiss.tech')
       && !hostname.includes('lovable.app');
 
     // Skip redirect logic for atlantiss.tech - let normal routing handle it
@@ -28,7 +28,7 @@ const DomainManager = ({ children }: DomainManagerProps) => {
       return;
     }
 
-    if (isCustomDomain) {
+    if (isCustomDomain || isLovableProjectDomain) {
       const storeSlug = getStoreSlugFromDomain(hostname);
 
       // Apply redirects ONLY if this domain is mapped to a store

--- a/src/utils/storeRedirects.ts
+++ b/src/utils/storeRedirects.ts
@@ -4,8 +4,10 @@
 
 // قائمة النطاقات المخصصة للمتاجر
 export const STORE_DOMAINS = {
-  // مثال: 'store.yourdomain.com': 'your-store-slug'
-  // يمكن إضافة نطاقات مخصصة هنا
+  // نطاق Lovable للنشر
+  'sawalshamel.lovableproject.com': 'my-boutique',
+  // النطاق المخصص للمتجر
+  'sawalshamel.com': 'my-boutique',
 } as const;
 
 // فحص إذا كان النطاق الحالي متجر


### PR DESCRIPTION
## Summary
- allow Lovable deployment domains to use the same store redirect logic as custom domains
- map the Lovable and custom production domains to the desired store slug

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d894b034c4832dbf812117f481f828