### PR TITLE
Propagate merchant shop id through isolated store checkout

### DIFF
--- a/src/components/store/IsolatedStoreLayout.tsx
+++ b/src/components/store/IsolatedStoreLayout.tsx
@@ -11,6 +11,7 @@ interface StoreData {
   id: string;
   store_name: string;
   store_slug: string;
+  shop_id: string;
   bio?: string;
   logo_url?: string;
   theme: string;
@@ -35,7 +36,7 @@ export const IsolatedStoreLayout: React.FC = () => {
     try {
       const { data: storeData, error: storeError } = await supabase
         .from('affiliate_stores')
-        .select('id, store_name, store_slug, bio, logo_url, theme')
+        .select('id, store_name, store_slug, shop_id, bio, logo_url, theme')
         .eq('store_slug', storeSlug)
         .eq('is_active', true)
         .single();

--- a/src/pages/storefront/IsolatedStoreCart.tsx
+++ b/src/pages/storefront/IsolatedStoreCart.tsx
@@ -24,6 +24,7 @@ interface StoreContextType {
     id: string;
     store_name: string;
     store_slug: string;
+    shop_id: string;
   };
 }
 

--- a/src/pages/storefront/IsolatedStoreCheckout.tsx
+++ b/src/pages/storefront/IsolatedStoreCheckout.tsx
@@ -26,6 +26,7 @@ interface StoreContextType {
     id: string;
     store_name: string;
     store_slug: string;
+    shop_id: string;
   };
 }
 
@@ -84,6 +85,7 @@ export const IsolatedStoreCheckout: React.FC = () => {
     try {
       const result = await storeOrderService.createOrderFromCart(
         cart.id,
+        store.shop_id,
         store.id,
         {
           customerName: formData.customerName,

--- a/src/pages/storefront/IsolatedStorefront.tsx
+++ b/src/pages/storefront/IsolatedStorefront.tsx
@@ -33,6 +33,7 @@ interface StoreContextType {
     id: string;
     store_name: string;
     store_slug: string;
+    shop_id: string;
   };
 }
 

--- a/src/pages/storefront/MyStoreOrders.tsx
+++ b/src/pages/storefront/MyStoreOrders.tsx
@@ -26,6 +26,7 @@ interface StoreContextType {
     id: string;
     store_name: string;
     store_slug: string;
+    shop_id: string;
   };
 }
 

--- a/src/services/storeOrderService.ts
+++ b/src/services/storeOrderService.ts
@@ -29,7 +29,8 @@ const generateOrderNumber = () =>
 export const storeOrderService = {
   async createOrderFromCart(
     cartId: string,
-    storeId: string,
+    shopId: string,
+    affiliateStoreId: string,
     orderData: CreateOrderData
   ) {
     try {
@@ -59,14 +60,14 @@ export const storeOrderService = {
       const tax = 0;
       const total = subtotal + shipping + tax;
 
-      const sessionId = localStorage.getItem(`store_session_${storeId}`);
+      const sessionId = localStorage.getItem(`store_session_${affiliateStoreId}`);
       const orderNumber = generateOrderNumber();
 
       const { data: order, error: orderError } = await supabase
         .from('ecommerce_orders')
         .insert({
-          shop_id: storeId,
-          affiliate_store_id: storeId,
+          shop_id: shopId,
+          affiliate_store_id: affiliateStoreId,
           buyer_session_id: sessionId,
           customer_name: orderData.customerName,
           customer_phone: orderData.customerPhone,
@@ -122,7 +123,7 @@ export const storeOrderService = {
         .delete()
         .eq('cart_id', cartId);
 
-      await this.updateStoreCustomerSimple(storeId, orderData, total);
+      await this.updateStoreCustomerSimple(affiliateStoreId, orderData, total);
 
       return {
         success: true,


### PR DESCRIPTION
## Summary
- include the merchant shop_id when loading affiliate store metadata
- expose shop_id through the isolated store outlet context and use it for checkout
- update storeOrderService to store the correct shop and affiliate store identifiers on orders

## Testing
- npm run lint *(fails due to existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68dac83b2224832dbe0d314ba1f6ccba