### PR TITLE
feat: let marketers curate products in promotional banners

### DIFF
--- a/src/components/marketing/BannerPreview.tsx
+++ b/src/components/marketing/BannerPreview.tsx
@@ -16,6 +16,57 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
   interactive = false,
   onInteraction
 }) => {
+  const products = Array.isArray(banner?.selectedProducts)
+    ? banner.selectedProducts
+    : Array.isArray(banner?.content_config?.selectedProducts)
+      ? banner.content_config.selectedProducts
+      : [];
+
+  const renderProductShowcase = (variant: 'grid' | 'list' = 'grid') => {
+    if (!products.length) return null;
+
+    if (variant === 'list') {
+      return (
+        <div className="flex flex-wrap gap-2 mt-3 justify-end">
+          {products.map((product: any) => (
+            <Badge key={product.id} variant="outline" className="bg-white/80 text-foreground">
+              {product.title}
+            </Badge>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4 text-right">
+        {products.map((product: any) => {
+          const imageUrl =
+            (Array.isArray(product.image_urls) && product.image_urls[0]) ||
+            (Array.isArray(product.images) && product.images[0]?.url) ||
+            '/placeholder.svg';
+
+          return (
+            <div
+              key={product.id}
+              className="bg-white/90 text-foreground rounded-lg p-4 shadow-sm flex gap-4"
+            >
+              <div className="w-20 h-20 rounded-md overflow-hidden bg-muted">
+                <img src={imageUrl} alt={product.title} className="w-full h-full object-cover" />
+              </div>
+              <div className="flex-1">
+                <h4 className="font-semibold mb-1 line-clamp-2">{product.title}</h4>
+                <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                  {product.description || 'منتج من متجرك'}
+                </p>
+                <span className="text-sm font-medium text-primary">{product.price_sar} ريال</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   const getAnimationVariants = () => {
     switch (banner.animation_type) {
       case 'slide':
@@ -92,7 +143,7 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
             </p>
           )}
           {(banner.button_text_ar || banner.button_text) && banner.button_url && (
-            <Button 
+            <Button
               size="lg"
               style={{ backgroundColor: banner.button_color }}
               className="hover:opacity-90"
@@ -101,6 +152,8 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
               <ExternalLink className="w-4 h-4 mr-2" />
             </Button>
           )}
+
+          {renderProductShowcase('grid')}
         </div>
       </div>
 
@@ -139,6 +192,7 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
               {banner.description_ar || banner.description}
             </span>
           )}
+          {renderProductShowcase('list')}
         </div>
       </div>
 
@@ -200,14 +254,16 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
             </p>
           )}
           {(banner.button_text_ar || banner.button_text) && banner.button_url && (
-            <Button 
-              size="sm" 
+            <Button
+              size="sm"
               className="w-full"
               style={{ backgroundColor: banner.button_color }}
             >
               {banner.button_text_ar || banner.button_text}
             </Button>
           )}
+
+          {renderProductShowcase('grid')}
         </div>
 
         {banner.show_close_button && (
@@ -254,7 +310,7 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
             </p>
           )}
           {(banner.button_text_ar || banner.button_text) && banner.button_url && (
-            <Button 
+            <Button
               size="lg"
               className="w-full"
               style={{ backgroundColor: banner.button_color }}
@@ -262,6 +318,8 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
               {banner.button_text_ar || banner.button_text}
             </Button>
           )}
+
+          {renderProductShowcase('grid')}
         </div>
 
         {banner.show_close_button && (

--- a/src/components/storefront/PromotionalBannerDisplay.tsx
+++ b/src/components/storefront/PromotionalBannerDisplay.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { usePromotionalBanners } from '@/hooks/usePromotionalBanners';
 import { BannerPreview } from '@/components/marketing/BannerPreview';
 import { motion, AnimatePresence } from 'framer-motion';
+import { supabase } from '@/integrations/supabase/client';
 
 interface PromotionalBannerDisplayProps {
   affiliateStoreId?: string;
@@ -16,7 +17,7 @@ export const PromotionalBannerDisplay: React.FC<PromotionalBannerDisplayProps> =
   position,
   className = ''
 }) => {
-  const [visibleBanners, setVisibleBanners] = useState<string[]>([]);
+  const [hiddenBanners, setHiddenBanners] = useState<string[]>([]);
   const { fetchActiveBanners, trackBannerInteraction } = usePromotionalBanners(
     undefined,
     affiliateStoreId
@@ -26,18 +27,57 @@ export const PromotionalBannerDisplay: React.FC<PromotionalBannerDisplayProps> =
   useEffect(() => {
     const loadBanners = async () => {
       const activeBanners = await fetchActiveBanners(bannerType, position);
-      setBanners(activeBanners);
-      
-      // تتبع مشاهدة البانرات
+      const productIdSet = new Set<string>();
+
       activeBanners.forEach((banner: any) => {
-        trackBannerInteraction(banner.id, 'impression');
+        const ids = Array.isArray(banner.content_config?.product_ids)
+          ? banner.content_config.product_ids
+          : [];
+        ids.forEach((id: string) => productIdSet.add(id));
+      });
+
+      let productsMap = new Map<string, any>();
+
+      if (productIdSet.size > 0) {
+        const { data, error } = await supabase
+          .from('products')
+          .select('id,title,description,price_sar,image_urls,images')
+          .in('id', Array.from(productIdSet));
+
+        if (!error && data) {
+          productsMap = new Map(data.map(product => [product.id, product]));
+        }
+      }
+
+      const enrichedBanners = activeBanners.map((banner: any) => {
+        const ids = Array.isArray(banner.content_config?.product_ids)
+          ? banner.content_config.product_ids
+          : [];
+
+        const selectedProducts = ids
+          .map((id: string) => productsMap.get(id))
+          .filter(Boolean);
+
+        return {
+          ...banner,
+          selectedProducts
+        };
+      });
+
+      setBanners(enrichedBanners);
+
+      // تتبع مشاهدة البانرات
+      enrichedBanners.forEach((banner: any) => {
+        if (!hiddenBanners.includes(banner.id)) {
+          trackBannerInteraction(banner.id, 'impression');
+        }
       });
     };
 
     if (affiliateStoreId) {
       loadBanners();
     }
-  }, [affiliateStoreId, bannerType, position, fetchActiveBanners, trackBannerInteraction]);
+  }, [affiliateStoreId, bannerType, position, fetchActiveBanners, trackBannerInteraction, hiddenBanners]);
 
   const handleBannerClick = (bannerId: string, buttonUrl?: string) => {
     trackBannerInteraction(bannerId, 'click');
@@ -48,7 +88,7 @@ export const PromotionalBannerDisplay: React.FC<PromotionalBannerDisplayProps> =
 
   const handleBannerClose = (bannerId: string) => {
     trackBannerInteraction(bannerId, 'close');
-    setVisibleBanners(prev => prev.filter(id => id !== bannerId));
+    setHiddenBanners(prev => [...prev, bannerId]);
   };
 
   const getAnimationVariants = (animationType: string) => {
@@ -87,7 +127,7 @@ export const PromotionalBannerDisplay: React.FC<PromotionalBannerDisplayProps> =
     <div className={`promotional-banner-container relative z-10 ${className}`}>
       <AnimatePresence>
         {banners
-          .filter(banner => !visibleBanners.includes(banner.id))
+          .filter(banner => !hiddenBanners.includes(banner.id))
           .map((banner) => (
             <motion.div
               key={banner.id}


### PR DESCRIPTION
## Summary
- allow marketers to choose store products when creating or editing promotional banners
- show selected products inside banner previews across all banner layouts
- hydrate storefront banner display with product details so the chosen items render in the live store

## Testing
- npx eslint src/components/marketing/BannerEditor.tsx src/components/marketing/BannerPreview.tsx src/components/storefront/PromotionalBannerDisplay.tsx

------
https://chatgpt.com/codex/tasks/task_b_68db0e36b948832da6eb6bcff9122750