### PR TITLE
fix: normalize banner product ids

### DIFF
--- a/src/components/marketing/BannerEditor.tsx
+++ b/src/components/marketing/BannerEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -28,6 +28,7 @@ import { ar } from 'date-fns/locale';
 import { motion } from 'framer-motion';
 import { usePromotionalBanners } from '@/hooks/usePromotionalBanners';
 import { BannerPreview } from './BannerPreview';
+import { supabase } from '@/integrations/supabase/client';
 
 interface BannerEditorProps {
   banner?: any;
@@ -45,7 +46,10 @@ export const BannerEditor: React.FC<BannerEditorProps> = ({
   onSave
 }) => {
   const { createBanner, updateBanner, isLoading } = usePromotionalBanners(storeId, affiliateStoreId);
-  
+
+  const [availableProducts, setAvailableProducts] = useState<any[]>([]);
+  const [productsLoading, setProductsLoading] = useState(false);
+  const [selectedProductIds, setSelectedProductIds] = useState<string[]>([]);
   const [formData, setFormData] = useState({
     title: '',
     title_ar: '',
@@ -105,19 +109,77 @@ export const BannerEditor: React.FC<BannerEditorProps> = ({
         show_close_button: banner.show_close_button ?? true,
         animation_type: banner.animation_type || 'fade'
       });
+      const bannerProductIds = Array.isArray(banner.content_config?.product_ids)
+        ? banner.content_config.product_ids.map((id: string | number) => id?.toString())
+        : [];
+      setSelectedProductIds(bannerProductIds);
     }
   }, [banner]);
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+      try {
+        setProductsLoading(true);
+        let query = supabase
+          .from('products')
+          .select('id,title,description,price_sar,image_urls,images,shop_id,is_active')
+          .eq('is_active', true);
+
+        const targetStoreId = storeId || affiliateStoreId;
+        if (targetStoreId) {
+          query = query.eq('shop_id', targetStoreId);
+        }
+
+        const { data, error } = await query;
+        if (error) throw error;
+
+        setAvailableProducts(data || []);
+      } catch (error) {
+        console.error('خطأ في جلب منتجات المتجر للبنر:', error);
+      } finally {
+        setProductsLoading(false);
+      }
+    };
+
+    fetchProducts();
+  }, [storeId, affiliateStoreId]);
 
   const handleInputChange = (field: string, value: any) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
+  const toggleProductSelection = (productId: string | number) => {
+    const normalizedId = productId?.toString();
+
+    setSelectedProductIds(prev => (
+      prev.includes(normalizedId)
+        ? prev.filter(id => id !== normalizedId)
+        : [...prev, normalizedId]
+    ));
+  };
+
+  const selectedProducts = useMemo(
+    () => {
+      const idSet = new Set(selectedProductIds.map(id => id?.toString()));
+      return availableProducts.filter(product => idSet.has(product.id?.toString()));
+    },
+    [availableProducts, selectedProductIds]
+  );
+
   const handleSubmit = async () => {
     try {
+      const payload = {
+        ...formData,
+        content_config: {
+          ...(formData.content_config || {}),
+          product_ids: selectedProductIds.map(id => id?.toString())
+        }
+      };
+
       if (banner) {
-        await updateBanner(banner.id, formData as any);
+        await updateBanner(banner.id, payload as any);
       } else {
-        await createBanner(formData as any);
+        await createBanner(payload as any);
       }
       onSave();
     } catch (error) {
@@ -159,8 +221,13 @@ export const BannerEditor: React.FC<BannerEditorProps> = ({
             {isLoading ? 'جاري الحفظ...' : 'حفظ البانر'}
           </Button>
         </div>
-        
-        <BannerPreview banner={formData} />
+
+        <BannerPreview
+          banner={{
+            ...formData,
+            selectedProducts
+          }}
+        />
       </div>
     );
   }
@@ -309,6 +376,79 @@ export const BannerEditor: React.FC<BannerEditorProps> = ({
                   />
                 </div>
               </div>
+            </CardContent>
+          </Card>
+
+          <Card className="mt-6">
+            <CardHeader>
+              <CardTitle>منتجات البانر</CardTitle>
+              <CardDescription>
+                اختر المنتجات التي ترغب في إبرازها داخل البانر من منتجات متجرك الحالية
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {productsLoading ? (
+                <div className="flex items-center justify-center py-6">
+                  <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+                </div>
+              ) : availableProducts.length === 0 ? (
+                <div className="text-center py-6 text-muted-foreground">
+                  لا توجد منتجات متاحة حالياً في متجرك. قم بإضافة منتجات أولاً لربطها بالبانر.
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {availableProducts.map((product) => {
+                    const normalizedId = product.id?.toString();
+                    const isSelected = normalizedId ? selectedProductIds.includes(normalizedId) : false;
+                    const imageUrl =
+                      (Array.isArray(product.image_urls) && product.image_urls[0]) ||
+                      (Array.isArray(product.images) && product.images[0]?.url) ||
+                      '/placeholder.svg';
+
+                    return (
+                      <button
+                        type="button"
+                        key={product.id}
+                        onClick={() => toggleProductSelection(product.id)}
+                        className={`relative text-right p-4 rounded-lg border transition-all focus:outline-none focus:ring-2 focus:ring-primary/60 focus:ring-offset-2 ${
+                          isSelected
+                            ? 'border-primary bg-primary/10 shadow-sm'
+                            : 'border-muted hover:border-primary/40'
+                        }`}
+                      >
+                        <div className="flex items-center gap-4">
+                          <div className="w-16 h-16 rounded-md overflow-hidden bg-muted">
+                            <img
+                              src={imageUrl}
+                              alt={product.title}
+                              className="w-full h-full object-cover"
+                            />
+                          </div>
+                          <div className="flex-1">
+                            <h4 className="font-semibold mb-1 line-clamp-1">{product.title}</h4>
+                            <p className="text-sm text-muted-foreground line-clamp-2">
+                              {product.description || 'بدون وصف'}
+                            </p>
+                            <div className="mt-2 text-sm font-medium text-primary">
+                              {product.price_sar} ريال
+                            </div>
+                          </div>
+                        </div>
+
+                        {isSelected && (
+                          <Badge className="absolute top-3 left-3">مضاف</Badge>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {selectedProductIds.length > 0 && (
+                <p className="text-sm text-muted-foreground text-right">
+                  سيتم عرض {selectedProductIds.length} منتج داخل البانر.
+                </p>
+              )}
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/components/marketing/BannerPreview.tsx
+++ b/src/components/marketing/BannerPreview.tsx
@@ -16,6 +16,57 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
   interactive = false,
   onInteraction
 }) => {
+  const products = Array.isArray(banner?.selectedProducts)
+    ? banner.selectedProducts
+    : Array.isArray(banner?.content_config?.selectedProducts)
+      ? banner.content_config.selectedProducts
+      : [];
+
+  const renderProductShowcase = (variant: 'grid' | 'list' = 'grid') => {
+    if (!products.length) return null;
+
+    if (variant === 'list') {
+      return (
+        <div className="flex flex-wrap gap-2 mt-3 justify-end">
+          {products.map((product: any) => (
+            <Badge key={product.id} variant="outline" className="bg-white/80 text-foreground">
+              {product.title}
+            </Badge>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4 text-right">
+        {products.map((product: any) => {
+          const imageUrl =
+            (Array.isArray(product.image_urls) && product.image_urls[0]) ||
+            (Array.isArray(product.images) && product.images[0]?.url) ||
+            '/placeholder.svg';
+
+          return (
+            <div
+              key={product.id}
+              className="bg-white/90 text-foreground rounded-lg p-4 shadow-sm flex gap-4"
+            >
+              <div className="w-20 h-20 rounded-md overflow-hidden bg-muted">
+                <img src={imageUrl} alt={product.title} className="w-full h-full object-cover" />
+              </div>
+              <div className="flex-1">
+                <h4 className="font-semibold mb-1 line-clamp-2">{product.title}</h4>
+                <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                  {product.description || 'منتج من متجرك'}
+                </p>
+                <span className="text-sm font-medium text-primary">{product.price_sar} ريال</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
   const getAnimationVariants = () => {
     switch (banner.animation_type) {
       case 'slide':
@@ -92,7 +143,7 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
             </p>
           )}
           {(banner.button_text_ar || banner.button_text) && banner.button_url && (
-            <Button 
+            <Button
               size="lg"
               style={{ backgroundColor: banner.button_color }}
               className="hover:opacity-90"
@@ -101,6 +152,8 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
               <ExternalLink className="w-4 h-4 mr-2" />
             </Button>
           )}
+
+          {renderProductShowcase('grid')}
         </div>
       </div>
 
@@ -139,6 +192,7 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
               {banner.description_ar || banner.description}
             </span>
           )}
+          {renderProductShowcase('list')}
         </div>
       </div>
 
@@ -200,14 +254,16 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
             </p>
           )}
           {(banner.button_text_ar || banner.button_text) && banner.button_url && (
-            <Button 
-              size="sm" 
+            <Button
+              size="sm"
               className="w-full"
               style={{ backgroundColor: banner.button_color }}
             >
               {banner.button_text_ar || banner.button_text}
             </Button>
           )}
+
+          {renderProductShowcase('grid')}
         </div>
 
         {banner.show_close_button && (
@@ -254,7 +310,7 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
             </p>
           )}
           {(banner.button_text_ar || banner.button_text) && banner.button_url && (
-            <Button 
+            <Button
               size="lg"
               className="w-full"
               style={{ backgroundColor: banner.button_color }}
@@ -262,6 +318,8 @@ export const BannerPreview: React.FC<BannerPreviewProps> = ({
               {banner.button_text_ar || banner.button_text}
             </Button>
           )}
+
+          {renderProductShowcase('grid')}
         </div>
 
         {banner.show_close_button && (


### PR DESCRIPTION
## Summary
- normalize stored and selected banner product identifiers to strings so toggling works reliably
- keep storefront banner hydration using the same normalization to load curated products consistently

## Testing
- npx eslint src/components/marketing/BannerEditor.tsx src/components/marketing/BannerPreview.tsx src/components/storefront/PromotionalBannerDisplay.tsx

------
https://chatgpt.com/codex/tasks/task_b_68db0e36b948832da6eb6bcff9122750