### PR TITLE
Fix affiliate store category settings save failure

### DIFF
--- a/src/hooks/useStoreSettings.ts
+++ b/src/hooks/useStoreSettings.ts
@@ -71,14 +71,15 @@ export const useStoreSettings = (storeId: string) => {
     if (!storeId) return false;
 
     try {
+      const payload: Partial<StoreSettings> & { store_id: string } = {
+        store_id: storeId,
+        ...(settings?.id ? { id: settings.id } : {}),
+        ...updates
+      };
+
       const { data, error } = await supabase
         .from('affiliate_store_settings')
-        .upsert({
-          store_id: storeId,
-          ...updates
-        }, {
-          onConflict: 'store_id'
-        })
+        .upsert(payload)
         .select()
         .single();
 


### PR DESCRIPTION
## Summary
- update affiliate store settings persistence to include the existing settings id during upsert operations, preventing save failures when storing category preferences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dd95315bc8832da11aa480601d877f