### PR TITLE
Fix decodeAssets dirname resolution

### DIFF
--- a/scripts/decodeAssets.mjs
+++ b/scripts/decodeAssets.mjs
@@ -3,8 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Buffer } from 'node:buffer';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_MANIFEST_URL = new URL('../assets/asset-manifest.json', import.meta.url);
 
 function normalizeManifestUrl(manifestUrl) {
@@ -74,7 +73,10 @@ export async function decodeAssetManifest(options = {}) {
 
     return { manifest, outputs };
   } catch (error) {
-    console.log('[decodeAssets] Skipping asset decode (no manifest found)');
+    console.log(
+      '[decodeAssets] Skipping asset decode (no manifest found):',
+      error?.message || error,
+    );
     return { manifest: null, outputs: [] };
   }
 }


### PR DESCRIPTION
## Summary
- inline the `fileURLToPath` result when deriving `__dirname` to avoid unused variables
- log the caught error when the manifest is missing so eslint recognizes the variable use

## Testing
- npm run lint *(fails: existing no-unused-vars warnings in public/sw.js)*

------
https://chatgpt.com/codex/tasks/task_b_68dd9b4d10dc832d8ab07e9e9c10e19d