### PR TITLE
Add public policy to expose active affiliate store settings

### DIFF
--- a/supabase/migrations/20250207120000_add_public_select_policy_affiliate_store_settings.sql
+++ b/supabase/migrations/20250207120000_add_public_select_policy_affiliate_store_settings.sql
@@ -1,0 +1,12 @@
+-- Allow unauthenticated visitors to read settings for active stores
+CREATE POLICY "Public can view active store settings"
+ON public.affiliate_store_settings
+FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.affiliate_stores
+    WHERE affiliate_stores.id = affiliate_store_settings.store_id
+      AND affiliate_stores.is_active = true
+  )
+);


### PR DESCRIPTION
## Summary
- add a migration that creates a SELECT policy so unauthenticated visitors can read affiliate store settings for active stores

## Testing
- npx supabase migration up *(fails: `config` parsing error about invalid keys `storage.port`, `auth.enable_email_autoconfirm`, `edge_runtime.port`)*
- curl https://uewuiiopkctdtaexmtxu.supabase.co/rest/v1/affiliate_store_settings?select=*

------
https://chatgpt.com/codex/tasks/task_b_68dd9cbac90c832daa5354c4aa3c7089