### PR TITLE
Add anon select policy for active affiliate store settings

### DIFF
--- a/supabase/migrations/20250929130853_8735ef62-b989-47e0-a17a-6b31740bd0b2.sql
+++ b/supabase/migrations/20250929130853_8735ef62-b989-47e0-a17a-6b31740bd0b2.sql
@@ -21,18 +21,31 @@ INSERT INTO storage.buckets (id, name, public) VALUES ('store-assets', 'store-as
 -- إنشاء سياسات الأمان للجدول
 ALTER TABLE public.affiliate_store_settings ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Store owners can manage their settings" 
-ON public.affiliate_store_settings 
-FOR ALL 
+CREATE POLICY "Store owners can manage their settings"
+ON public.affiliate_store_settings
+FOR ALL
 USING (store_id IN (
-  SELECT affiliate_stores.id 
-  FROM affiliate_stores 
+  SELECT affiliate_stores.id
+  FROM affiliate_stores
   WHERE affiliate_stores.profile_id IN (
-    SELECT profiles.id 
-    FROM profiles 
+    SELECT profiles.id
+    FROM profiles
     WHERE profiles.auth_user_id = auth.uid()
   )
 ));
+
+CREATE POLICY "Anonymous users can view settings for active stores"
+ON public.affiliate_store_settings
+FOR SELECT
+TO anon
+USING (
+  EXISTS (
+    SELECT 1
+    FROM affiliate_stores
+    WHERE affiliate_stores.id = affiliate_store_settings.store_id
+      AND affiliate_stores.is_active = true
+  )
+);
 
 -- إنشاء سياسات التخزين
 CREATE POLICY "Store owners can upload assets" 


### PR DESCRIPTION
## Summary
- grant the anon role SELECT access to affiliate_store_settings
- limit the policy to settings belonging to active affiliate stores

## Testing
- not run (database access not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dda1a18948832daf16a48fab5e7765