### PR TITLE
Adjust anon affiliate store settings policy migration

### DIFF
--- a/supabase/migrations/20250929130853_8735ef62-b989-47e0-a17a-6b31740bd0b2.sql
+++ b/supabase/migrations/20250929130853_8735ef62-b989-47e0-a17a-6b31740bd0b2.sql
@@ -34,19 +34,6 @@ USING (store_id IN (
   )
 ));
 
-CREATE POLICY "Anonymous users can view settings for active stores"
-ON public.affiliate_store_settings
-FOR SELECT
-TO anon
-USING (
-  EXISTS (
-    SELECT 1
-    FROM affiliate_stores
-    WHERE affiliate_stores.id = affiliate_store_settings.store_id
-      AND affiliate_stores.is_active = true
-  )
-);
-
 -- إنشاء سياسات التخزين
 CREATE POLICY "Store owners can upload assets" 
 ON storage.objects 

--- a/supabase/migrations/20251001215622_anon_affiliate_store_settings_policy.sql
+++ b/supabase/migrations/20251001215622_anon_affiliate_store_settings_policy.sql
@@ -1,0 +1,14 @@
+DROP POLICY IF EXISTS "Anonymous users can view settings for active stores" ON public.affiliate_store_settings;
+
+CREATE POLICY "Anonymous users can view settings for active stores"
+ON public.affiliate_store_settings
+FOR SELECT
+TO anon
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.affiliate_stores
+    WHERE affiliate_stores.id = affiliate_store_settings.store_id
+      AND affiliate_stores.is_active = true
+  )
+);


### PR DESCRIPTION
## Summary
- remove the anonymous affiliate store settings policy from the original migration
- add a follow-up migration to drop and recreate the anonymous view policy for active stores

## Testing
- `supabase db push` *(fails: Supabase CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dda36d3820832d9fafeaf888f14084