### PR TITLE
refactor: simplify aurora boutique theme assets

### DIFF
--- a/public/themes/aurora-boutique.svg
+++ b/public/themes/aurora-boutique.svg
@@ -1,0 +1,37 @@
+<svg width="320" height="180" viewBox="0 0 320 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="auroraGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9D4EDD" />
+      <stop offset="45%" stop-color="#F15BB5" />
+      <stop offset="100%" stop-color="#00BBF9" />
+    </linearGradient>
+    <linearGradient id="glowGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(255, 255, 255, 0.9)" />
+      <stop offset="100%" stop-color="rgba(255, 255, 255, 0)" />
+    </linearGradient>
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="15" result="blur" />
+      <feBlend in="SourceGraphic" in2="blur" mode="screen" />
+    </filter>
+  </defs>
+  <rect width="320" height="180" rx="24" fill="#F4ECFF" />
+  <rect x="20" y="20" width="280" height="140" rx="20" fill="white" stroke="#DCC8FF" stroke-width="2" />
+  <path
+    d="M20 118C60 98 96 134 132 122C168 110 178 72 220 78C262 84 280 46 300 58"
+    stroke="url(#auroraGradient)"
+    stroke-width="12"
+    stroke-linecap="round"
+    filter="url(#softGlow)"
+  />
+  <path
+    d="M32 124C72 104 112 148 152 130C192 112 212 68 256 78C284 84 296 70 308 74"
+    stroke="url(#glowGradient)"
+    stroke-width="18"
+    stroke-linecap="round"
+  />
+  <circle cx="88" cy="68" r="14" fill="#FEE440" opacity="0.8" />
+  <circle cx="244" cy="54" r="10" fill="#00F5D4" opacity="0.6" />
+  <text x="40" y="156" fill="#4A266A" font-family="'Poppins', 'Cairo', sans-serif" font-size="20" font-weight="600">
+    Aurora Boutique
+  </text>
+</svg>

--- a/src/components/store/StoreThemeSelector.tsx
+++ b/src/components/store/StoreThemeSelector.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Check, Crown, Palette, Sparkles, Users, Zap } from 'lucide-react';
+import {
+  Check,
+  Crown,
+  Image as ImageIcon,
+  Palette,
+  Sparkles,
+  Users,
+  Zap
+} from 'lucide-react';
 import { useStoreThemes, StoreTheme } from '@/hooks/useStoreThemes';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -11,12 +19,41 @@ interface StoreThemeSelectorProps {
   onThemeApplied?: (theme: StoreTheme) => void;
 }
 
+const AuroraIcon: React.FC = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <defs>
+      <linearGradient id="aurora-icon-gradient" x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+        <stop offset="0%" stopColor="#9D4EDD" />
+        <stop offset="50%" stopColor="#F15BB5" />
+        <stop offset="100%" stopColor="#00BBF9" />
+      </linearGradient>
+    </defs>
+    <rect x="3" y="3" width="18" height="18" rx="5" fill="#F4ECFF" />
+    <path
+      d="M5 15C7.5 13 9.5 16.5 12 15.5C14.5 14.5 15 11 18 11.5C20 11.9 21 10 21 10"
+      stroke="url(#aurora-icon-gradient)"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <circle cx="9" cy="9" r="1.6" fill="#FEE440" />
+    <circle cx="16.5" cy="7.5" r="1.2" fill="#00F5D4" />
+  </svg>
+);
+
 const ThemeIcon = ({ themeName }: { themeName: string }) => {
   switch (themeName.toLowerCase()) {
     case 'modern minimalist':
       return <Zap className="w-5 h-5" />;
     case 'luxury premium':
       return <Crown className="w-5 h-5" />;
+    case 'aurora boutique':
+      return <AuroraIcon />;
     case 'traditional arabic':
       return <Palette className="w-5 h-5" />;
     case 'colorful vibrant':
@@ -136,6 +173,34 @@ export const StoreThemeSelector: React.FC<StoreThemeSelectorProps> = ({
               </CardHeader>
 
               <CardContent className="space-y-4">
+                {theme.preview_image_url && (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <Badge
+                        variant="outline"
+                        className="flex items-center gap-1 border-primary/30 text-primary"
+                      >
+                        <ImageIcon className="w-3 h-3" />
+                        معاينة
+                      </Badge>
+                      <a
+                        href={theme.preview_image_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-primary hover:underline"
+                      >
+                        فتح في نافذة جديدة
+                      </a>
+                    </div>
+                    <img
+                      src={theme.preview_image_url}
+                      alt={`معاينة ثيم ${theme.name_ar}`}
+                      className="w-full h-32 object-cover rounded-md border border-border/60"
+                      loading="lazy"
+                    />
+                  </div>
+                )}
+
                 <ThemePreview theme={theme} />
                 
                 <div className="flex flex-wrap gap-2 text-xs">

--- a/supabase/migrations/20251003120000_add_aurora_boutique_theme.sql
+++ b/supabase/migrations/20251003120000_add_aurora_boutique_theme.sql
@@ -1,0 +1,47 @@
+-- إضافة ثيم Aurora Boutique
+INSERT INTO public.store_themes (
+  name,
+  name_ar,
+  description,
+  description_ar,
+  theme_config,
+  preview_image_url,
+  is_active,
+  is_premium
+) VALUES (
+  'Aurora Boutique',
+  'أورورا بوتيك',
+  'Dreamy boutique theme with aurora-inspired gradients for fashion and beauty brands',
+  'ثيم بوتيك حالم بألوان الشفق يناسب علامات الأزياء والجمال العصرية',
+  '{
+    "colors": {
+      "primary": "hsl(276, 72%, 45%)",
+      "secondary": "hsl(318, 64%, 95%)",
+      "accent": "hsl(196, 91%, 55%)",
+      "background": "hsl(276, 58%, 97%)",
+      "foreground": "hsl(276, 30%, 20%)",
+      "muted": "hsl(300, 20%, 90%)",
+      "card": "hsl(0, 0%, 100%)",
+      "border": "hsl(280, 35%, 85%)"
+    },
+    "typography": {
+      "fontFamily": "'Poppins', 'Cairo', sans-serif",
+      "headingFont": "'Cormorant Garamond', 'Cairo', serif"
+    },
+    "layout": {
+      "borderRadius": "16px",
+      "spacing": "airy",
+      "cardStyle": "layered"
+    },
+    "effects": {
+      "shadows": "soft-glow",
+      "animations": "floaty",
+      "gradients": true,
+      "glassmorphism": true
+    }
+  }',
+  '/themes/aurora-boutique.svg',
+  true,
+  false
+)
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## Summary
- replace the Aurora Boutique thumbnail asset with an inline-friendly SVG illustration
- point the Supabase migration to the SVG preview and keep theme metadata intact
- render a bespoke Aurora icon in the theme selector instead of reusing a stock lucide glyph

## Testing
- npm run lint *(fails: existing no-unused-vars errors in public/sw.js)*

------
https://chatgpt.com/codex/tasks/task_b_68def4dc2480832da242ee88a2087830